### PR TITLE
deprecated class

### DIFF
--- a/domain_adaptation/train.py
+++ b/domain_adaptation/train.py
@@ -14,7 +14,6 @@ from chainer import optimizers, serializers
 from chainer.functions.evaluation import accuracy
 from chainer.training import extensions
 from chainer.datasets import tuple_dataset
-from chainercv.datasets import TransformDataset
 from chainercv.visualizations import vis_image
 from c3dmodels import Loss, Discriminator
 from updater import ADDAUpdater


### PR DESCRIPTION
`from chainercv.datasets import TransformDataset`
"This class is deprecated. Please use chainer.datasets.TransformDataset instead."
Source: https://chainercv.readthedocs.io/en/v0.6.0/reference/datasets.html